### PR TITLE
Find command: make matching case insensitive and matches to dates

### DIFF
--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -10,22 +10,23 @@ import duke.task.TaskList;
 import duke.task.Todo;
 
 public class FindCommand extends Command {
-    private String InputToSearch;
-    public FindCommand(String input) {
-        this.InputToSearch = input;
+    private String input;
+    public FindCommand(String input) throws DukeException {
+        String[] inputArr = input.split(" ", 2);
+        if (inputArr.length == 1 || inputArr[1].isBlank()) {
+            throw new DukeException("Sorry, the description of the task cannot be empty!");
+        }
+        this.input = inputArr[1];
     }
+
     public String execute(TaskList taskList, Ui ui, Storage storage) throws DukeException {
-        ArrayList<Task> foundTasks = taskList.findTasks(this.InputToSearch);
+        ArrayList<Task> foundTasks = taskList.findTasks(this.input);
         if (foundTasks.size() == 0) {
             return "We could not find any matching tasks.";
         } else {
-            String response = "Here are the matching tasks in your list:";
-            for (Task foundTask : foundTasks) {
-                    String taskString = foundTasks.indexOf(foundTask) + 1 + ". [" + foundTask.getSymbol() + "] "
-                            + "[" + foundTask.getStatusIcon() + "] " + foundTask.getDescription();
-                if (!(foundTask instanceof Todo)) {
-                    taskString += " (" + foundTask.getDuedateString() + ")";
-                }
+            String response = "Here are the matching tasks in your list:\n";
+            for (Task task : foundTasks) {
+                    String taskString = taskList.formatTaskToString(task);
                     response += taskString + "\n";
             }
             return response;

--- a/src/main/java/duke/parser/Parser.java
+++ b/src/main/java/duke/parser/Parser.java
@@ -68,7 +68,7 @@ public class Parser {
             Event event = new Event(fullCommand);
             return new AddCommand(event);
         case find:
-            return new FindCommand(fullCommandArr[1]);
+            return new FindCommand(fullCommand);
         case mark:
             return new MarkCommand(Integer.parseInt(fullCommandArr[1]));
         case unmark:

--- a/src/main/java/duke/parser/Query.java
+++ b/src/main/java/duke/parser/Query.java
@@ -29,6 +29,7 @@ public class Query {
 
     /**
      * Determines if a string consists of only numbers
+     *
      * @param str String to check
      * @return a boolean indicating whether the string is numeric or not.
      */
@@ -44,6 +45,7 @@ public class Query {
 
     /**
      * Returns a QueryType that determines what type of command the input is.
+     *
      * @param input String to check.
      * @return A QueryType indicating the type of command.
      */
@@ -55,7 +57,9 @@ public class Query {
         }
 
         String[] inputArr = input.split(" ");
-        if (inputArr.length == 2 && isNumeric(inputArr[1])) {
+        if (inputArr[0].equals("find")) {
+            return QueryType.find;
+        } else if (inputArr.length == 2 && isNumeric(inputArr[1])) {
             if (inputArr[0].equals("mark")) {
                 return QueryType.mark;
             } else if (inputArr[0].equals("unmark")) {
@@ -63,8 +67,6 @@ public class Query {
             } else if (inputArr[0].equals("delete")) {
                 return QueryType.delete;
             }
-        } else if (inputArr[0].equals("find")) {
-            return QueryType.find;
         } else if (inputArr[0].equals("todo")) {
             return QueryType.todo;
         } else if (inputArr[0].equals("deadline")) {

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -11,7 +11,7 @@ import duke.parser.Parser;
  * Represents a Deadline Task that has a description and a due date.
  */
 public class Deadline extends Task {
-    protected LocalDate duedate;
+    protected String duedate;
 
     /**
      * Constructor for Deadline task, loaded from the storage file.
@@ -22,9 +22,9 @@ public class Deadline extends Task {
         super(input, isDone);
         this.symbol = 'D';
         String[] temp = input.split(",");
-        this.description = temp[0];
+        this.description = temp[0].trim();
         LocalDate inputFormatter = LocalDate.parse(temp[1]);
-        this.duedate = inputFormatter;
+        this.duedate = inputFormatter.toString();
         this.duedateString = inputFormatter.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG));
     }
 
@@ -46,11 +46,15 @@ public class Deadline extends Task {
         }
         this.description = descriptionArr[0];
         LocalDate inputFormatter = Parser.parseDate(descriptionArr[1]);
-        this.duedate = inputFormatter;
+        this.duedate = inputFormatter.toString();
         this.duedateString = inputFormatter.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG));
     }
     public String saveTask() {
         return this.symbol + "," + isDone + "," + this.description + "," + duedate;
+    }
+
+    public String getDuedate() {
+        return this.duedate.toString();
     }
 }
 

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -10,8 +10,8 @@ import duke.parser.Parser;
  * Represents an Event task that has a description, a start date and time as well as an end date and time.
  */
 public class Event extends Task {
-    protected LocalDateTime startTime;
-    protected LocalDateTime endTime;
+    protected String startTime;
+    protected String endTime;
     protected DateTimeFormatter displayFormatter = DateTimeFormatter.ofPattern("MMM dd yyyy HHmm");
 
     /**
@@ -23,10 +23,10 @@ public class Event extends Task {
         super(input, isDone);
         this.symbol = 'E';
         String[] temp = input.split(",");
-        this.description = temp[0];
+        this.description = temp[0].trim();
         String[] dueArr = temp[1].split(" to ");
-        this.startTime = LocalDateTime.parse(dueArr[0], displayFormatter);
-        this.endTime = LocalDateTime.parse(dueArr[1], displayFormatter);
+        this.startTime = LocalDateTime.parse(dueArr[0], displayFormatter).toString();
+        this.endTime = LocalDateTime.parse(dueArr[1], displayFormatter).toString();
         this.duedateString = temp[1];
     }
 
@@ -49,9 +49,10 @@ public class Event extends Task {
         }
         this.description = eventArr[0];
         String[] dueArr = eventArr[1].split(" to ");
-        this.startTime = Parser.parseDateTime(dueArr[0]);
-        this.endTime = Parser.parseDateTime(dueArr[1]);
-        this.duedateString = startTime.format(displayFormatter) + " to " + endTime.format(displayFormatter);
+        this.startTime = Parser.parseDateTime(dueArr[0]).toString();
+        this.endTime = Parser.parseDateTime(dueArr[1]).toString();
+        this.duedateString = startTime + " to " + endTime;
+
     }
     public String saveTask() {
         return this.symbol + "," + isDone + "," + this.description + "," + duedateString;

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -73,12 +73,22 @@ public class TaskList {
     }
 
     public ArrayList<Task> findTasks(String input) {
+        String inputToLowerCase = input.toLowerCase().trim();
         ArrayList<Task> foundTasks = new ArrayList<>();
-        for (Task cur : this.tasks) {
-            if (cur.getDescription().contains(input)) {
-                foundTasks.add(cur);
+        for (Task task : this.tasks) {
+            if (task.getDescription().toLowerCase().contains(inputToLowerCase)) {
+                foundTasks.add(task);
+            } else if (task instanceof Deadline) {
+                if (((Deadline) task).duedate.contains(inputToLowerCase) || task.getDuedateString().contains(inputToLowerCase)) {
+                    foundTasks.add(task);
+                }
+            } else if (task instanceof Event) {
+                if (task.getDuedateString().contains(inputToLowerCase) || ((Event) task).startTime.contains(inputToLowerCase) || ((Event) task).endTime.contains(inputToLowerCase)) {
+                    foundTasks.add(task);
+                }
             }
         }
+                //if event or deadline, check dates
         return foundTasks;
     }
     public int getNumTasks() {

--- a/src/main/java/duke/task/Todo.java
+++ b/src/main/java/duke/task/Todo.java
@@ -29,7 +29,7 @@ public class Todo extends Task {
         if (inputArr.length == 1 || inputArr[1].isBlank()) {
             throw new DukeException("Sorry, the description of a todo cannot be empty!");
         }
-        this.description = inputArr[1];
+        this.description = inputArr[1].trim();
     }
 
     public String saveTask() {


### PR DESCRIPTION
Find functionality is case sensitive, and only matches to tasks description.

A case insensitive find is more user-friendly because users cannot be expected to remember exact case of keywords. A find feature that matches dates is more user-friendly for users to see what events and deadlines they have on that day.

Let's,
* update the search algorithm to use case-insensitive matching
* update the search algorithm to match dates in the form <yyyy-MM-dd> or <MMM dd yyyy>